### PR TITLE
Adds unique bottom sheet functionality

### DIFF
--- a/packages/stacked_services/CHANGELOG.md
+++ b/packages/stacked_services/CHANGELOG.md
@@ -1,6 +1,21 @@
+## 0.8.15
+
+### Bottom Sheet Unique Name
+When showing a bottom sheet we'll now give it a uique route name based on the properties passed in. The format of this will differ between the general and custom.
+- general: `general_{md5hashOfTitleAndDescription}
+- custom: `variant_{md5HashOfTitleDescriptionMainButtonTitleSecondaryButtonTitle}
+
+The expected output of a bottom sheet will look like this
+
+```dart
+general_82fda55933c6a64eb961dfb6e13bdd4f // General and confirmation bottom sheet
+BottomSheetType.FloatingBox_33557de8784ebb01ebd64b71926b5933 // Custom Bottom sheet with variant
+```
+
 ## 0.8.14
 
 - Updated `get` to latest package version
+
 ## 0.8.13
 
 - Updated `get` to latest package version

--- a/packages/stacked_services/example/lib/main.dart
+++ b/packages/stacked_services/example/lib/main.dart
@@ -24,10 +24,43 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      navigatorObservers: [StackedService.routeObserver],
+      navigatorObservers: [
+        StackedService.routeObserver,
+        _LoggingObserver(),
+      ],
       navigatorKey: StackedService.navigatorKey,
       initialRoute: auto_router.Routes.homeScreenRoute,
       onGenerateRoute: auto_router.Router().onGenerateRoute,
     );
+  }
+}
+
+class _LoggingObserver extends NavigatorObserver {
+  @override
+  void didPop(Route route, Route previousRoute) {
+    print(
+        'route.name: ${route?.settings?.name}, previousRoute.name: ${previousRoute?.settings?.name}');
+    super.didPop(route, previousRoute);
+  }
+
+  @override
+  void didRemove(Route route, Route previousRoute) {
+    print(
+        'route.name: ${route?.settings?.name}, previousRoute.name: ${previousRoute?.settings?.name}');
+    super.didRemove(route, previousRoute);
+  }
+
+  @override
+  void didPush(Route route, Route previousRoute) {
+    print(
+        'route.name: ${route?.settings?.name}, previousRoute.name: ${previousRoute?.settings?.name}');
+    super.didPush(route, previousRoute);
+  }
+
+  @override
+  void didReplace({Route newRoute, Route oldRoute}) {
+    print(
+        'newRoute.name: ${newRoute?.settings?.name}, oldRoute.name: ${oldRoute?.settings?.name}');
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
   }
 }

--- a/packages/stacked_services/lib/src/bottom_sheet/bottom_sheet_service.dart
+++ b/packages/stacked_services/lib/src/bottom_sheet/bottom_sheet_service.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:stacked_services/src/models/overlay_request.dart';
 import 'package:stacked_services/src/models/overlay_response.dart';
+import 'dart:convert';
+import 'package:crypto/crypto.dart';
 
 import 'bottom_sheet_ui.dart';
 
@@ -57,6 +59,11 @@ class BottomSheetService {
       exitBottomSheetDuration: exitBottomSheetDuration,
       enterBottomSheetDuration: enterBottomSheetDuration,
       ignoreSafeArea: ignoreSafeArea,
+      settings: RouteSettings(
+          name: 'general_${_hashConcateator([
+            title,
+            description,
+          ])}'),
     );
   }
 
@@ -111,36 +118,42 @@ class BottomSheetService {
     final sheetBuilder = _sheetBuilders![variant];
 
     return Get.bottomSheet<SheetResponse<T>>(
-      Material(
-        type: MaterialType.transparency,
-        child: sheetBuilder!(
-          Get.context!,
-          SheetRequest<R>(
-            title: title,
-            description: description,
-            hasImage: hasImage,
-            imageUrl: imageUrl,
-            showIconInMainButton: showIconInMainButton,
-            mainButtonTitle: mainButtonTitle,
-            showIconInSecondaryButton: showIconInSecondaryButton,
-            secondaryButtonTitle: secondaryButtonTitle,
-            showIconInAdditionalButton: showIconInAdditionalButton,
-            additionalButtonTitle: additionalButtonTitle,
-            takesInput: takesInput,
-            customData: customData,
-            variant: variant,
-            data: data,
+        Material(
+          type: MaterialType.transparency,
+          child: sheetBuilder!(
+            Get.context!,
+            SheetRequest<R>(
+              title: title,
+              description: description,
+              hasImage: hasImage,
+              imageUrl: imageUrl,
+              showIconInMainButton: showIconInMainButton,
+              mainButtonTitle: mainButtonTitle,
+              showIconInSecondaryButton: showIconInSecondaryButton,
+              secondaryButtonTitle: secondaryButtonTitle,
+              showIconInAdditionalButton: showIconInAdditionalButton,
+              additionalButtonTitle: additionalButtonTitle,
+              takesInput: takesInput,
+              customData: customData,
+              variant: variant,
+              data: data,
+            ),
+            completeSheet,
           ),
-          completeSheet,
         ),
-      ),
-      isDismissible: barrierDismissible,
-      isScrollControlled: isScrollControlled,
-      enableDrag: barrierDismissible && enableDrag,
-      exitBottomSheetDuration: exitBottomSheetDuration,
-      enterBottomSheetDuration: enterBottomSheetDuration,
-      ignoreSafeArea: ignoreSafeArea,
-    );
+        isDismissible: barrierDismissible,
+        isScrollControlled: isScrollControlled,
+        enableDrag: barrierDismissible && enableDrag,
+        exitBottomSheetDuration: exitBottomSheetDuration,
+        enterBottomSheetDuration: enterBottomSheetDuration,
+        ignoreSafeArea: ignoreSafeArea,
+        settings: RouteSettings(
+            name: '$variant\_${_hashConcateator([
+              title,
+              description,
+              mainButtonTitle,
+              secondaryButtonTitle,
+            ])}'));
   }
 
   /// Check if bottomsheet is open
@@ -150,4 +163,12 @@ class BottomSheetService {
   void completeSheet(SheetResponse response) {
     Get.back(result: response);
   }
+}
+
+String _hashConcateator(List<String?> objects) {
+  return _generateMd5(objects.join(''));
+}
+
+String _generateMd5(String input) {
+  return md5.convert(utf8.encode(input)).toString();
 }

--- a/packages/stacked_services/pubspec.yaml
+++ b/packages/stacked_services/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_services
 description: A package that contains some default implementations of services required for a cleaner implementation of the Stacked Architecture.
-version: 0.8.14
+version: 0.8.15
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_services
 
 environment:
@@ -12,6 +12,8 @@ dependencies:
 
   # navigation
   get: ^4.3.8
+
+  crypto: ^3.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
When showing a bottom sheet we'll now give it a uique route name based on the properties passed in. The format of this will differ between the general and custom.

- general: `general_{md5hashOfTitleAndDescription}
- custom: `variant_{md5HashOfTitleDescriptionMainButtonTitleSecondaryButtonTitle}

The expected output of a bottom sheet will look like this

```dart
general_82fda55933c6a64eb961dfb6e13bdd4f // General and confirmation bottom sheet
BottomSheetType.FloatingBox_33557de8784ebb01ebd64b71926b5933 // Custom Bottom sheet with variant
```