### PR TITLE
fix(1181): Navigator2 - Navigation animation glitches on back gesture (Android only)

### DIFF
--- a/lib/src/router/widgets/route_navigator.dart
+++ b/lib/src/router/widgets/route_navigator.dart
@@ -74,10 +74,12 @@ class RouteNavigatorState extends State<RouteNavigator> {
             onDidRemovePage: (page) {
               // Critical for Navigator 2.0: Clean up page state after removal
               // The framework handles didPop and page removal automatically
-              // Use notify: false to avoid triggering rebuild during animation
+              // Defer state update to after the animation frame completes
               if (page is StackedPage) {
-                widget.router.removeRoute(page.routeData, notify: false);
-                widget.didPop?.call(page.routeData.route, null);
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  widget.router.removeRoute(page.routeData);
+                  widget.didPop?.call(page.routeData.route, null);
+                });
               }
             },
           )

--- a/lib/src/router/widgets/route_navigator.dart
+++ b/lib/src/router/widgets/route_navigator.dart
@@ -71,21 +71,14 @@ class RouteNavigatorState extends State<RouteNavigator> {
             restorationScopeId:
                 widget.navRestorationScopeId ?? widget.router.routeData.name,
             pages: widget.router.stack,
-            // TODO: onPopPage is deprecated, migrate to onDidRemovePage
-            onPopPage: (route, result) {
-              // Critical for Navigator 2.0: Handle pop before it completes
-              // This prevents animation glitches on Android predictive back gestures
-              if (!route.didPop(result)) {
-                return false;
+            onDidRemovePage: (page) {
+              // Critical for Navigator 2.0: Clean up page state after removal
+              // The framework handles didPop and page removal automatically
+              // Use notify: false to avoid triggering rebuild during animation
+              if (page is StackedPage) {
+                widget.router.removeRoute(page.routeData, notify: false);
+                widget.didPop?.call(page.routeData.route, null);
               }
-
-              if (route.settings is StackedPage) {
-                var page = route.settings as StackedPage;
-                widget.router.removeRoute(page.routeData);
-                widget.didPop?.call(page.routeData.route, result);
-              }
-
-              return true;
             },
           )
         : widget.placeholder?.call(context) ??


### PR DESCRIPTION
## Description

This PR fixes two issues with Navigator 2.0 integration in Stacked's router:

1. **"Future already completed" error** during back gestures
2. **Animation glitches** on Android (forward flash before backward animation)

## Issues

### Issue 1: Future Already Completed

**Reproduction**:
1. Enable Navigator 2.0 in Stacked (`navigator2: true` in build.yaml)
2. Navigate to any route
3. Perform a back gesture (swipe from edge on iOS/Android)
4. Error: `Bad state: Future already completed`

**Root Cause**:
- Navigator 2.0's declarative API rebuilds page stacks during gestures
- `StackedPage.canUpdate()` returns `true` for matching pages
- The same `StackedPage` instance is reused
- `createRoute()` is called multiple times on the same instance
- Each call attempts to complete the same `_popCompleter`

## Deprecated warnings
It uses the deprecated member `onPopPage: (route, result)` (lib/src/router/widgets/route_navigator.dart) as I didn't find any way to fix that using `onDidRemovePage: (page)`.
Any feedback welcome on that! 

## Breaking Changes

None. The changes are internal to `StackedPage` and `RouteNavigator` and maintain backward compatibility.

## Checklist

- [x] Fixes are limited to the specific issues
- [x] Code follows existing style/conventions
- [x] No breaking changes to public API
- [x] Comments explain the "why" behind changes
- [x] All existing tests pass
- [ ] Added tests for the fixes (if applicable)
- [ ] Updated documentation (if needed)

## Additional Context

These issues appear when using Navigator 2.0 with the declarative API. Navigator 1.0 is unaffected as it uses imperative navigation.

The fixes follow Flutter's own Navigator 2.0 patterns and align with the official documentation for implementing custom page-based navigation.

## Related Issues

#1181 