### PR TITLE
Fix duplicate Route on pop with Android predictive back

### DIFF
--- a/lib/src/router/stacked_page.dart
+++ b/lib/src/router/stacked_page.dart
@@ -61,9 +61,20 @@ abstract class StackedPage<T> extends Page<T> {
   @override
   Route<T> createRoute(BuildContext context) {
     return onCreateRoute(context)
-      ..popped.then(
-        _popCompleter.complete,
-      );
+      ..popped.then((value) {
+        if (_popCompleter.isCompleted) return;
+        _popCompleter.complete(value);
+        // Synchronously remove this page from the router's stack. Without this,
+        // Flutter's Navigator may rebuild between pop and onDidRemovePage,
+        // see the stale page in `_pages`, and create a duplicate Route —
+        // which causes a "snap back" animation glitch on Android predictive
+        // back, and previously also threw "Future already completed" when
+        // the duplicate Route eventually popped.
+        final router = routeData.router;
+        if (router is StackRouter) {
+          router.removeRoute(routeData, notify: true);
+        }
+      });
   }
 }
 


### PR DESCRIPTION
When a route is popped (especially via the Android predictive back gesture), Flutter's page-based Navigator can rebuild between the pop and the asynchronous onDidRemovePage callback. During that window, `_pages` still contains the popped StackedPage, so the Navigator sees it as "missing from entries" and creates a duplicate Route via createRoute. This manifests as:

- "Bad state: Future already completed" thrown when the duplicate Route eventually pops (its popped future tries to complete the same _popCompleter again)
- A visible "snap back then swipe away" animation glitch on Android predictive back, because the phantom second Route runs an enter animation before being popped itself

Fix: in StackedPage.createRoute, when the Route's popped future fires, synchronously remove the page from the router's stack instead of waiting for onDidRemovePage. Also guard _popCompleter against double-completion for defense in depth.

Reproduces on Android 14+ with predictive back enabled, any pushed route, when the user swipes back quickly.